### PR TITLE
Only load Kirki on the backend

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,9 +11,6 @@
  *  Load theme files
 /* ------------------------------------------------------------------------- */	
 
-// Load Kirki
-include( get_template_directory() . '/functions/kirki/kirki.php' );
-
 if ( ! function_exists( 'boxcard_load' ) ) {
 	
 	function boxcard_load() {

--- a/functions/theme-options.php
+++ b/functions/theme-options.php
@@ -1,4 +1,12 @@
 <?php
+if (!is_admin()) {
+	// We don't need Kirki on the frontend
+	return;
+}
+
+// Load Kirki
+include( get_template_directory() . '/functions/kirki/kirki.php' );
+
 if ( ! class_exists( 'Kirki' ) ) {
 	return;
 }


### PR DESCRIPTION
Hi,
Here is an optimization for Boxcard : only load Kirki when we need it : on the admin backend. On the frontend, it is not used.
This allows for a faster init of Boxcard and better performance of the whole blog.

Attached is a call trace of boxcard_load() before the change :
![image](https://user-images.githubusercontent.com/1016317/155275934-33f04364-927b-43cd-9e4a-832a37bb4649.png)
(You can see boxcard_load() takes 17ms, most of it in Kirki functions)

Here is a call trace after the change :
![image](https://user-images.githubusercontent.com/1016317/155276060-56262eba-d48c-4494-83e7-0f571c528a6d.png)
You can see boxcard_load() now takes less than one millisecond.

Hope this helps !